### PR TITLE
two warnings/bugs found

### DIFF
--- a/octaveInterface/octaveinterface.cpp
+++ b/octaveInterface/octaveinterface.cpp
@@ -324,6 +324,7 @@ bool    octaveInterface::save_workspace_to_file(QString filename)
 {
     if (_workspace == nullptr) return false;
     _workspace->save_to_file(filename.toStdString());
+    return true;
 }
 
 

--- a/radarModules/radarparameter.cpp
+++ b/radarModules/radarparameter.cpp
@@ -2138,7 +2138,7 @@ template<> bool radarParameter<int32_t>::split_values(const QByteArray& data)
     _value.resize(dim_vector(1,res.quot));
     for (int n=0, p=0; n < res.quot; n++, p+=4)
     {
-        int16_t dest;
+        int32_t dest;
         char* _pdest = (char*)(&dest);
         strncpy(_pdest,data.mid(p, 4).data(),4);
         _value.elem(n) = dest;

--- a/uiElements/mdioctaveinterface.ui
+++ b/uiElements/mdioctaveinterface.ui
@@ -145,7 +145,7 @@
          <widget class="QWidget" name="layoutWidget">
           <layout class="QVBoxLayout" name="verticalLayout">
            <item>
-            <widget class="QLabel" name="label_2">
+            <widget class="QLabel" name="label">
              <property name="text">
               <string>Output</string>
              </property>
@@ -160,10 +160,10 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="layoutWidget">
+         <widget class="QWidget" name="layoutWidget_2">
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QLabel" name="label_3">
+            <widget class="QLabel" name="label_2">
              <property name="text">
               <string>History</string>
              </property>
@@ -182,10 +182,10 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="layoutWidget">
-      <layout class="QHBoxLayout" name="horizontalLayout">
+     <widget class="QWidget" name="layoutWidget_3">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Command</string>
          </property>


### PR DESCRIPTION
1)
Line 323 in octaveInterface/octaveinterface.cpp
```
bool    octaveInterface::save_workspace_to_file(QString filename)
{
    if (_workspace == nullptr) return false;
    _workspace->save_to_file(filename.toStdString());
}
```
This should either be labeled as void instead of bool, or return true after the workspace->save_to_file function, since that function returns void

2)
Line 2141 in radarModules/radarparameter.cpp
```
template<> bool radarParameter<int32_t>::split_values(const QByteArray& data)
{
    _value.clear();
    div_t res = std::div((int)data.length(), 4);
    if (res.rem!=0) return false;
    _value.resize(dim_vector(1,res.quot));
    for (int n=0, p=0; n < res.quot; n++, p+=4)
    {
        int16_t dest;
        char* _pdest = (char*)(&dest);
        strncpy(_pdest,data.mid(p, 4).data(),4);
        _value.elem(n) = dest;
    }
    return true;
}
```
This should be int32_t not int16_t for dest